### PR TITLE
compile-time specification of scalar type

### DIFF
--- a/include/Config.h
+++ b/include/Config.h
@@ -6,7 +6,11 @@ namespace MiniDNN
 
 
 // Floating-point number type
+#ifndef MDNN_SCALAR
 typedef double Scalar;
+#else
+typedef MDNN_SCALAR Scalar;
+#endif
 
 
 } // namespace MiniDNN

--- a/include/RNG.h
+++ b/include/RNG.h
@@ -55,10 +55,10 @@ class RNG
             m_rand = (seed ? (seed & m_max) : 1);
         }
 
-        virtual double rand()
+        virtual Scalar rand()
         {
             m_rand = next_long_rand(m_rand);
-            return double(m_rand) / double(m_max);
+            return Scalar(m_rand) / Scalar(m_max);
         }
 };
 

--- a/include/Utils/MiniDNNStream.h
+++ b/include/Utils/MiniDNNStream.h
@@ -242,7 +242,7 @@ void read_dense_tensor(TensorType& Tensor, std::string folder,
 }
 
 ///
-/// @brief      Write a std::vector<double> to file.
+/// @brief      Write a std::vector<Scalar> to file.
 ///
 /// @param[in]  myVector  The vector you want to write
 /// @param[in]  filename  The filename of the std::vector
@@ -253,11 +253,11 @@ void write_vector_to_file(const std::vector<Scalar>& myVector,
     std::ofstream ofs(filename.c_str(), std::ios::out | std::ios::binary);
     std::ostream_iterator<char> osi(ofs);
     const char* beginByte = (char*)&myVector[0];
-    const char* endByte = (char*)&myVector.back() + sizeof(double);
+    const char* endByte = (char*)&myVector.back() + sizeof(Scalar);
     std::copy(beginByte, endByte, osi);
 }
 ///
-/// @brief      Reads a std::vector<double> from file.
+/// @brief      Reads a std::vector<Scalar> from file.
 ///
 /// @param[in]  filename  The filename of the vector
 ///
@@ -270,7 +270,7 @@ std::vector<Scalar> read_vector_from_file(std::string filename)
     std::istreambuf_iterator<char> iter(ifs);
     std::istreambuf_iterator<char> end;
     std::copy(iter, end, std::back_inserter(buffer));
-    std::vector<double> newVector(buffer.size() / sizeof(double));
+    std::vector<Scalar> newVector(buffer.size() / sizeof(Scalar));
     memcpy(&newVector[0], &buffer[0], buffer.size());
     return newVector;
 }
@@ -530,7 +530,7 @@ std::ostream& operator<<(std::ostream& os,
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, std::vector<double>& myVector)
+std::ostream& operator<<(std::ostream& os, std::vector<Scalar>& myVector)
 {
     for (int i = 0; i < myVector.size(); i++)
     {


### PR DESCRIPTION
Hi!
Well done creating this library. It looks fantastic! 

This is a rather minor change. It adds a compilation flag for the Scalar type (-DMDNN_SCALAR). I thought that would be more convenient than changing/patching the config.h file. I've made a few more changes down the line so the types would be Scalar rather than double. 

In order to test this with float types (-DMDNN_SCALAR=float), I've changed the type definitions in the example.cpp as follows:

```
...
using namespace MiniDNN;

typedef Eigen::Matrix<float, Eigen::Dynamic, Eigen::Dynamic>  Matrix;
typedef Eigen::Vector<float, Eigen::Dynamic> Vector;
...

```

Thanks!
Ben.
