### PR TITLE
new compiler flag for storage order

### DIFF
--- a/include/Activation/Identity.h
+++ b/include/Activation/Identity.h
@@ -20,7 +20,6 @@ namespace MiniDNN
 class Identity
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
 
     public:
         // a = activation(z) = z

--- a/include/Activation/Mish.h
+++ b/include/Activation/Mish.h
@@ -18,7 +18,6 @@ namespace MiniDNN
 class Mish
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
 
     public:
         // Mish(x) = x * tanh(softplus(x))

--- a/include/Activation/ReLU.h
+++ b/include/Activation/ReLU.h
@@ -16,7 +16,6 @@ namespace MiniDNN
 class ReLU
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
 
     public:
         // a = activation(z) = max(z, 0)

--- a/include/Activation/Sigmoid.h
+++ b/include/Activation/Sigmoid.h
@@ -16,7 +16,6 @@ namespace MiniDNN
 class Sigmoid
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
 
     public:
         // a = activation(z) = 1 / (1 + exp(-z))

--- a/include/Activation/Softmax.h
+++ b/include/Activation/Softmax.h
@@ -13,7 +13,6 @@ namespace MiniDNN
 class Softmax
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
         typedef Eigen::Array<Scalar, 1, Eigen::Dynamic> RowArray;
 
     public:

--- a/include/Activation/Tanh.h
+++ b/include/Activation/Tanh.h
@@ -16,7 +16,6 @@ namespace MiniDNN
 class Tanh
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
 
     public:
         // a = activation(z) = tanh(z)

--- a/include/Callback.h
+++ b/include/Callback.h
@@ -29,7 +29,6 @@ class Network;
 class Callback
 {
     protected:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
         typedef Eigen::RowVectorXi IntegerVector;
 
     public:

--- a/include/Config.h
+++ b/include/Config.h
@@ -4,15 +4,20 @@
 namespace MiniDNN
 {
 
-typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
-typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
-
 // Floating-point number type
 #ifndef MDNN_SCALAR
 typedef double Scalar;
 #else
 typedef MDNN_SCALAR Scalar;
 #endif
+
+#if(MDNN_ROWMAJOR == 1)
+typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> Matrix;
+#else
+typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
+#endif
+
+typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
 
 
 } // namespace MiniDNN

--- a/include/Config.h
+++ b/include/Config.h
@@ -4,6 +4,8 @@
 namespace MiniDNN
 {
 
+typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
+typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
 
 // Floating-point number type
 #ifndef MDNN_SCALAR

--- a/include/Layer.h
+++ b/include/Layer.h
@@ -26,8 +26,6 @@ namespace MiniDNN
 class Layer
 {
     protected:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
         typedef std::map<std::string, int> MetaInfo;
 
         const int m_in_size;  // Size of input units

--- a/include/Layer/Convolutional.h
+++ b/include/Layer/Convolutional.h
@@ -27,8 +27,6 @@ template <typename Activation>
 class Convolutional: public Layer
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
         typedef Matrix::ConstAlignedMapType ConstAlignedMapMat;
         typedef Vector::ConstAlignedMapType ConstAlignedMapVec;
         typedef Vector::AlignedMapType AlignedMapVec;

--- a/include/Layer/FullyConnected.h
+++ b/include/Layer/FullyConnected.h
@@ -23,8 +23,6 @@ template <typename Activation>
 class FullyConnected: public Layer
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
         typedef Vector::ConstAlignedMapType ConstAlignedMapVec;
         typedef Vector::AlignedMapType AlignedMapVec;
         typedef std::map<std::string, int> MetaInfo;

--- a/include/Layer/MaxPooling.h
+++ b/include/Layer/MaxPooling.h
@@ -25,7 +25,6 @@ template <typename Activation>
 class MaxPooling: public Layer
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
         typedef Eigen::MatrixXi IntMatrix;
         typedef std::map<std::string, int> MetaInfo;
 

--- a/include/Network.h
+++ b/include/Network.h
@@ -32,7 +32,6 @@ namespace MiniDNN
 class Network
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
         typedef Eigen::RowVectorXi IntegerVector;
         typedef std::map<std::string, int> MetaInfo;
 
@@ -437,10 +436,19 @@ class Network
             // We want to force XType and YType to be column-majored
             typedef typename Eigen::MatrixBase<DerivedX>::PlainObject PlainObjectX;
             typedef typename Eigen::MatrixBase<DerivedY>::PlainObject PlainObjectY;
+
+#if (MDNN_ROWMAJOR == 1 )
+            typedef Eigen::Matrix<typename PlainObjectX::Scalar, PlainObjectX::RowsAtCompileTime, PlainObjectX::ColsAtCompileTime, Eigen::RowMajor>
+            XType;
+            typedef Eigen::Matrix<typename PlainObjectY::Scalar, PlainObjectY::RowsAtCompileTime, PlainObjectY::ColsAtCompileTime, Eigen::RowMajor>
+            YType;
+#else
             typedef Eigen::Matrix<typename PlainObjectX::Scalar, PlainObjectX::RowsAtCompileTime, PlainObjectX::ColsAtCompileTime>
             XType;
             typedef Eigen::Matrix<typename PlainObjectY::Scalar, PlainObjectY::RowsAtCompileTime, PlainObjectY::ColsAtCompileTime>
             YType;
+#endif
+
             const int nlayer = num_layers();
 
             if (nlayer <= 0)

--- a/include/Optimizer.h
+++ b/include/Optimizer.h
@@ -20,7 +20,6 @@ namespace MiniDNN
 class Optimizer
 {
     protected:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
         typedef Vector::ConstAlignedMapType ConstAlignedMapVec;
         typedef Vector::AlignedMapType AlignedMapVec;
 

--- a/include/Optimizer/AdaGrad.h
+++ b/include/Optimizer/AdaGrad.h
@@ -18,7 +18,6 @@ namespace MiniDNN
 class AdaGrad: public Optimizer
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
         typedef Eigen::Array<Scalar, Eigen::Dynamic, 1> Array;
         typedef Vector::ConstAlignedMapType ConstAlignedMapVec;
         typedef Vector::AlignedMapType AlignedMapVec;

--- a/include/Optimizer/Adam.h
+++ b/include/Optimizer/Adam.h
@@ -18,7 +18,6 @@ namespace MiniDNN
 class Adam: public Optimizer
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
         typedef Eigen::Array<Scalar, Eigen::Dynamic, 1> Array;
         typedef Vector::ConstAlignedMapType ConstAlignedMapVec;
         typedef Vector::AlignedMapType AlignedMapVec;

--- a/include/Optimizer/RMSProp.h
+++ b/include/Optimizer/RMSProp.h
@@ -18,7 +18,6 @@ namespace MiniDNN
 class RMSProp: public Optimizer
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
         typedef Eigen::Array<Scalar, Eigen::Dynamic, 1> Array;
         typedef Vector::ConstAlignedMapType ConstAlignedMapVec;
         typedef Vector::AlignedMapType AlignedMapVec;

--- a/include/Optimizer/SGD.h
+++ b/include/Optimizer/SGD.h
@@ -17,7 +17,6 @@ namespace MiniDNN
 class SGD: public Optimizer
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
         typedef Vector::ConstAlignedMapType ConstAlignedMapVec;
         typedef Vector::AlignedMapType AlignedMapVec;
 

--- a/include/Output.h
+++ b/include/Output.h
@@ -23,8 +23,6 @@ namespace MiniDNN
 class Output
 {
     protected:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
         typedef Eigen::RowVectorXi IntegerVector;
 
     public:

--- a/include/Output/RegressionMSE.h
+++ b/include/Output/RegressionMSE.h
@@ -17,8 +17,6 @@ namespace MiniDNN
 class RegressionMSE: public Output
 {
     private:
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
-        typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
 
         Matrix m_din;  // Derivative of the input of this layer.
         // Note that input of this layer is also the output of previous layer

--- a/include/Utils/Convolution.h
+++ b/include/Utils/Convolution.h
@@ -131,8 +131,8 @@ inline void moving_product(
     const int step,
     const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
     mat1,
-    Eigen::Map< const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> >& mat2,
-    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& res
+    Eigen::Map< const Matrix >& mat2,
+    Matrix& res
 )
 {
     const int row1 = mat1.rows();
@@ -156,7 +156,6 @@ inline void convolve_valid(
     const Scalar* filter_data,
     Scalar* dest)
 {
-    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
     typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
     RMatrix;
     typedef Eigen::Map<const Matrix> ConstMapMat;
@@ -243,8 +242,8 @@ inline void moving_product(
     const int padding, const int step,
     const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>&
     mat1,
-    const Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& mat2,
-    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& res
+    const Matrix& mat2,
+    Matrix & res
 )
 {
     const int row1 = mat1.rows();
@@ -294,7 +293,6 @@ inline void convolve_full(
     const Scalar* src, const int n_obs, const Scalar* filter_data,
     Scalar* dest)
 {
-    typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> Matrix;
     typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>
     RMatrix;
     typedef Eigen::Map<const Matrix> ConstMapMat;


### PR DESCRIPTION
Hi
This is a bit along the same lines as the last PR, but with storage order. I noticed there were a lot of Matrix and Vector typedefs, so I pulled them all together into Config.h, and then decided it would be nice to be able to define storage order, i.e. row or column major, at compile time.

So there's a new compiler flag MDNN_ROWMAJOR that if set to 1 will mean matrices will be row-major.

Test: (I'll attach the mostly unchanged example.cpp for convenience)
```
> g++ -I ./include/ example.cpp -DMDNN_ROWMAJOR=1
> ./a.out
(base) ben@Ben-xubuntu:~/MiniDNN$ ./a.out 
IsRowMajor?: 1
[Epoch 0, batch 0] Loss = 0.328066
[Epoch 1, batch 0] Loss = 0.327707
[Epoch 2, batch 0] Loss = 0.327475
[Epoch 3, batch 0] Loss = 0.327273
[Epoch 4, batch 0] Loss = 0.327095
[Epoch 5, batch 0] Loss = 0.32692
[Epoch 6, batch 0] Loss = 0.326753
[Epoch 7, batch 0] Loss = 0.326593
[Epoch 8, batch 0] Loss = 0.326437
[Epoch 9, batch 0] Loss = 0.326274

> g++ -I ./include/ example.cpp
> ./a.out 
IsRowMajor?: 0
[Epoch 0, batch 0] Loss = 0.32792
[Epoch 1, batch 0] Loss = 0.326679
[Epoch 2, batch 0] Loss = 0.325873
[Epoch 3, batch 0] Loss = 0.325187
[Epoch 4, batch 0] Loss = 0.324576
[Epoch 5, batch 0] Loss = 0.324013
[Epoch 6, batch 0] Loss = 0.323497
[Epoch 7, batch 0] Loss = 0.323033
[Epoch 8, batch 0] Loss = 0.322599
[Epoch 9, batch 0] Loss = 0.322178
```
