### PR TITLE
Replacing <windows.h> with <direct.h> in Utils/IO.h

### DIFF
--- a/include/Utils/IO.h
+++ b/include/Utils/IO.h
@@ -11,7 +11,8 @@
 #include <cstdlib>   // atoi
 
 #ifdef _WIN32
-    #include <windows.h>  // _mkdir
+    //#include <windows.h>  // _mkdir
+    #include <direct.h>     // here _mkdir is living.
 #else
     #include <sys/stat.h> // mkdir
 #endif

--- a/include/Utils/IO.h
+++ b/include/Utils/IO.h
@@ -11,8 +11,7 @@
 #include <cstdlib>   // atoi
 
 #ifdef _WIN32
-    //#include <windows.h>  // _mkdir
-    #include <direct.h>     // here _mkdir is living.
+    #include <direct.h>     // _mkdir
 #else
     #include <sys/stat.h> // mkdir
 #endif


### PR DESCRIPTION
I was working on some code with your library (which is awesome) when I stumbled across this little mistake. Here is a fix. The `_mkdir` function does not live in `<windows.h>` but in `<direct.h>`. It was only affecting the Windows version.